### PR TITLE
add slog logging solution

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,6 +1,13 @@
 package cmd
 
-import "github.com/spf13/cobra"
+import (
+	"io"
+	"log/slog"
+	"os"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/natefinch/lumberjack.v2"
+)
 
 func Execute() {
 	var root = &cobra.Command{
@@ -8,5 +15,44 @@ func Execute() {
 	}
 
 	root.AddCommand(decodeCmd(), infoCmd(), peersCmd(), handshakeCmd(), downloadPieceCmd())
+
+	var verbose bool
+	root.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
+		if err := setupLogger(verbose); err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	root.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "whether to send logs to stdout")
+
 	root.Execute()
+}
+
+func setupLogger(verbose bool) error {
+	var out io.Writer
+
+	fileout := &lumberjack.Logger{
+		Filename:   os.ExpandEnv("$HOME/.local/share/btor/btor.log"),
+		MaxSize:    100,
+		MaxBackups: 2,
+		MaxAge:     28,
+	}
+
+	if verbose {
+		out = io.MultiWriter(os.Stdout, fileout)
+	} else {
+		out = fileout
+	}
+
+	logger := slog.New(
+		slog.NewTextHandler(
+			out,
+			nil,
+		),
+	)
+
+	slog.SetDefault(logger)
+	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/spf13/cobra v1.8.1
 	golang.org/x/sync v0.8.0
+	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -13,4 +13,6 @@ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 golang.org/x/sync v0.8.0 h1:3NFvSEYkUoMifnESzZl15y791HH1qU2xm6eCJU5ZPXQ=
 golang.org/x/sync v0.8.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/natefinch/lumberjack.v2 v2.2.1 h1:bBRl1b0OH9s/DuPhuXpNl+VtCaJXFZ5/uEFST95x9zc=
+gopkg.in/natefinch/lumberjack.v2 v2.2.1/go.mod h1:YD8tP3GAjkrDg1eZH7EGmyESg/lsYskCTPBJVb9jqSc=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
- Configure root command to pre-run a logger setup function
- By default, send log to `$HOME/.local/share/btor/btor.log`
- If `verbose` flag is used, also output logs to stdout